### PR TITLE
Relax upper bound on purescript-react

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "purescript-web-dom": "^2.0.0",
-    "purescript-react": "^6.0.0",
+    "purescript-react": ">= 6.0.0 < 8.0.0",
     "purescript-effect": "^2.0.0"
   }
 }


### PR DESCRIPTION
This is necessary to allow this package to compile with purs v0.13.0
(see also: https://github.com/purescript-contrib/purescript-react/pull/171)