### PR TITLE
Specify extension in react-dom/server import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Added .js extension to react-dom/server import to aid bundlers like Webpack (#32 by @thomashoneyman)
 
 Other improvements:
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.15/src/packages.dhall
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220504/packages.dhall
+        sha256:fd37736ecaa24491c907af6a6422156417f21fbf25763de19f65bd641e8340d3
 
 in  upstream

--- a/src/ReactDOM.js
+++ b/src/ReactDOM.js
@@ -1,5 +1,5 @@
 import ReactDOM from "react-dom";
-import ReactDOMServer from "react-dom/server";
+import ReactDOMServer from "react-dom/server.js";
 
 export function renderImpl(element, container) {
   return ReactDOM.render(element, container);


### PR DESCRIPTION
**Description of the change**

Fixes #31 by adding a `.js` extension to the `react-dom/server` import.